### PR TITLE
feat(react): migrate icons for component `Select`

### DIFF
--- a/packages/components/react/select/select-trigger.tsx
+++ b/packages/components/react/select/select-trigger.tsx
@@ -16,7 +16,9 @@ const SelectTrigger = React.forwardRef<Comp, Props>(({ className, shadow, childr
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-chevron-down"><path d="m6 9 6 6 6-6" /></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" color="foreground" fill="none">
+          <path d="M18 9.00005C18 9.00005 13.5811 15 12 15C10.4188 15 6 9 6 9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )


### PR DESCRIPTION
# Migrate icons for component Select

## Introduction

In this PR the style of the icons for the Select component has been migrated.

## Preview

### Before
![image](https://github.com/OpenLab-dev/openui/assets/128724547/ff23631b-f809-4ee6-b489-501ab45ceaa5)

### After
mode light

![Captura de pantalla 2024-05-19 203947](https://github.com/OpenLab-dev/openui/assets/128724547/155c3447-cc70-4446-8ebf-dc1f2eb85319)

mode dark

![Captura de pantalla 2024-05-19 205406](https://github.com/OpenLab-dev/openui/assets/128724547/b948a22c-6e83-4935-9e77-78a1ba95eae6)
