### PR TITLE
feat(theme): added new styles for component `Skeleton`

### DIFF
--- a/packages/components/react/skeleton/skeleton.tsx
+++ b/packages/components/react/skeleton/skeleton.tsx
@@ -8,13 +8,12 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement>,
 function Skeleton({
   className,
   rounded,
-  icons,
   children,
   ...props
 }: Props) {
   return (
     <div
-      className={cn(skeleton({ rounded, icons }), className)}
+      className={cn(skeleton({ rounded }), className)}
       {...props}
     >
       {children}

--- a/packages/components/react/skeleton/skeleton.tsx
+++ b/packages/components/react/skeleton/skeleton.tsx
@@ -1,17 +1,24 @@
 import React from 'react'
 import { cn, skeleton } from '@openui-org/theme'
+import type { VariantProps } from '@openui-org/theme'
 
-export interface Props extends React.HTMLAttributes<HTMLDivElement> {}
+export interface Props extends React.HTMLAttributes<HTMLDivElement>,
+  VariantProps<typeof skeleton> {}
 
 function Skeleton({
   className,
+  rounded,
+  icons,
+  children,
   ...props
 }: Props) {
   return (
     <div
-      className={cn(skeleton(), className)}
+      className={cn(skeleton({ rounded, icons }), className)}
       {...props}
-    />
+    >
+      {children}
+    </div>
   )
 }
 

--- a/packages/theme/src/components/skeleton.ts
+++ b/packages/theme/src/components/skeleton.ts
@@ -10,7 +10,7 @@ import { cva } from 'class-variance-authority'
  *   // Skeleton elements
  * </Skeleton>
  */
-export const skeleton = cva('animate-pulse-infinite bg-default rounded-full', {
+export const skeleton = cva('animate-pulse-infinite bg-default', {
   variants: {
     rounded: {
       none: 'rounded-none',
@@ -19,13 +19,8 @@ export const skeleton = cva('animate-pulse-infinite bg-default rounded-full', {
       lg: 'rounded-lg',
       full: 'rounded-full',
     },
-    icons: {
-      none: '',
-      activate: 'flex items-center justify-center',
-    },
   },
   defaultVariants: {
     rounded: 'full',
-    icons: 'none',
   },
 })

--- a/packages/theme/src/components/skeleton.ts
+++ b/packages/theme/src/components/skeleton.ts
@@ -10,4 +10,22 @@ import { cva } from 'class-variance-authority'
  *   // Skeleton elements
  * </Skeleton>
  */
-export const skeleton = cva('animate-pulse bg-foreground/20 rounded-full')
+export const skeleton = cva('animate-pulse-infinite bg-default rounded-full', {
+  variants: {
+    rounded: {
+      none: 'rounded-none',
+      sm: 'rounded-sm',
+      md: 'rounded-md',
+      lg: 'rounded-lg',
+      full: 'rounded-full',
+    },
+    icons: {
+      none: '',
+      activate: 'flex items-center justify-center',
+    },
+  },
+  defaultVariants: {
+    rounded: 'full',
+    icons: 'none',
+  },
+})

--- a/packages/theme/src/styles/animations/index.ts
+++ b/packages/theme/src/styles/animations/index.ts
@@ -5,6 +5,8 @@ export const animations = {
     'pulse-fade-in': 'pulse-fade-in 0.3s ease-out',
     'dialog-in': 'dialog-in 0.3s ease-out',
     'dialog-out': 'dialog-out 0.3s ease-out',
+    'pulse-infinite': 'pulse-infinite 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+
   },
   keyframes: {
     'pulse': {
@@ -16,6 +18,17 @@ export const animations = {
       },
       '100%': {
         transform: 'scale(1)',
+      },
+    },
+    'pulse-infinite': {
+      '0%': {
+        opacity: 1,
+      },
+      '50%': {
+        opacity: 0.5,
+      },
+      '100%': {
+        opacity: 1,
       },
     },
     'pop': {


### PR DESCRIPTION
# Styles for component Skeleton

## Introduction

In this PR add new feature for component Skeleton, it is about styles:

## Details

Added new variants like: 
- rounded

## Api refernece

```ts
 const variants = {
   rounded: {
      none: 'rounded-none',
      sm: 'rounded-sm',
      md: 'rounded-md',
      lg: 'rounded-lg',
      full: 'rounded-full',
   }
}
```
## new animation

```ts
const animations = {
  animation: {
    'pulse-infinite': 'pulse-infinite 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
  },
  keyframes: {
    'pulse-infinite': {
      '0%': {
        opacity: 1,
      },
      '50%': {
        opacity: 0.5,
      },
      '100%': {
        opacity: 1,
      },
    },
  },
}
```

## Related problems

Resolves #250

## Preview
By default, for rounded the variant is `full` and icons is `none`

mode light

https://github.com/OpenLab-dev/openui/assets/128724547/1b09d59e-5157-4a64-bf20-348b5954fac3

mode dark

https://github.com/OpenLab-dev/openui/assets/128724547/e8e068a8-227a-40af-a92e-c12507616b78

## How to use

```tsx
import { Skeleton} from '@openui-org/react'

function CheckboxExample() {
return <Skeleton/>
}
```