### PR TITLE
feat(theme): added new styles for component `Progress`

### DIFF
--- a/packages/theme/src/components/progress.ts
+++ b/packages/theme/src/components/progress.ts
@@ -11,7 +11,7 @@ import { cva } from 'class-variance-authority'
  * </Progress>
  */
 
-export const progress = cva('relative bg-foreground/10 w-full overflow-hidden rounded-full', {
+export const progress = cva('relative bg-default w-full overflow-hidden rounded-full', {
   variants: {
     size: {
       sm: 'h-2',


### PR DESCRIPTION
# Styles for component Progress

## Introduction

The Progress component fund was modified.

## Related problems

Resolves #253

## Preview
by default, the component has bakground `primary` and size `md`

mode light

![Captura de pantalla 2024-05-20 135128](https://github.com/OpenLab-dev/openui/assets/128724547/252af5da-11f3-471f-8a2f-4b1629b03416)

mode dark

![Captura de pantalla 2024-05-20 135311](https://github.com/OpenLab-dev/openui/assets/128724547/afc2c77b-a847-48eb-9e1c-0b9347a73b22)

## How to use

```tsx
import { Progress } from '@openui-org/react'

function CheckboxExample() {
return <Progress  />
}
```