### PR TITLE
feat(vue): added new component `Label`

### DIFF
--- a/packages/components/vue/index.ts
+++ b/packages/components/vue/index.ts
@@ -1,2 +1,3 @@
 export * from './accordion'
 export * from './button'
+export * from './label'

--- a/packages/components/vue/label/index.ts
+++ b/packages/components/vue/label/index.ts
@@ -1,0 +1,1 @@
+export { default as Label } from './label.vue'

--- a/packages/components/vue/label/label.vue
+++ b/packages/components/vue/label/label.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { Label } from 'radix-vue'
+import { cn, label } from '@openui-org/theme'
+
+interface Props {
+    size?: NonNullable<Parameters<typeof label>[0]>['size']
+    textColor?: NonNullable<Parameters<typeof label>[0]>['textColor']
+    as?: string
+}
+
+withDefaults(defineProps<Props>(), {
+  as: 'label',
+})
+
+</script>
+
+<template>
+  <Label
+    :class="
+      cn(
+        label({ size, textColor }, $attrs.class ?? ''))
+    "
+    >
+    <slot />
+  </Label>
+</template>

--- a/packages/components/vue/label/label.vue
+++ b/packages/components/vue/label/label.vue
@@ -3,24 +3,14 @@ import { Label } from 'radix-vue'
 import { cn, label } from '@openui-org/theme'
 
 interface Props {
-    size?: NonNullable<Parameters<typeof label>[0]>['size']
-    textColor?: NonNullable<Parameters<typeof label>[0]>['textColor']
-    as?: string
+  size?: NonNullable<Parameters<typeof label>[0]>['size']
+  textColor?: NonNullable<Parameters<typeof label>[0]>['textColor']
 }
-
-withDefaults(defineProps<Props>(), {
-  as: 'label',
-})
-
+withDefaults(defineProps<Props>(), {})
 </script>
 
 <template>
-  <Label
-    :class="
-      cn(
-        label({ size, textColor }, $attrs.class ?? ''))
-    "
-    >
+  <Label :class="cn(label({ size, textColor }, $attrs.class ?? ''))">
     <slot />
   </Label>
 </template>

--- a/packages/theme/src/components/label.ts
+++ b/packages/theme/src/components/label.ts
@@ -11,13 +11,13 @@ import { cva } from 'class-variance-authority'
  * </Label>
  */
 export const label = cva(
-  'text-small font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  'font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
   {
     variants: {
       size: {
-        sm: 'text-small',
-        md: 'text-medium',
-        lg: 'text-large',
+        sm: 'text-sm',
+        md: 'text-md',
+        lg: 'text-lg',
       },
       textColor: {
         none: 'text-foreground/70',

--- a/packages/theme/src/components/label.ts
+++ b/packages/theme/src/components/label.ts
@@ -15,9 +15,9 @@ export const label = cva(
   {
     variants: {
       size: {
-        sm: 'text-sm',
-        md: 'text-md',
-        lg: 'text-lg',
+        sm: 'text-small',
+        md: 'text-medium',
+        lg: 'text-large',
       },
       textColor: {
         none: 'text-foreground/70',


### PR DESCRIPTION
# New component Label for Vue

## Introduction

label component was created for vue

## Details 

Added new variants like

- size
- textColor

## Api Reference

```ts
conts variants: {
    size: {
      sm: 'text-small',
      md: 'text-medium',
      lg: 'text-large',
    },
    textColor: {
      none: 'text-foreground/70',
      primary: 'text-primary/80',
      success: 'text-success/80',
      warn: 'text-warn/80',
      error: 'text-error/80',
    },
}
```

## Related problems

Resolves #317 

## Preview
By default, for size the variant is `md` and textColor is `none`


![Captura de pantalla 2024-05-23 134512](https://github.com/OpenLab-dev/openui/assets/128724547/d6843845-c0a3-4989-a5e5-19f23368a28c)

## How to use

```vue
<script setup lang="ts">
import { Label } from '@openui-org/vue'
</script>

<template>
  <Label>Name</Label>
</template>
```